### PR TITLE
🌐 优化中文支持：为 core/app 模块添加完整简体中文翻译

### DIFF
--- a/core/app/src/main/res/values-zh-rCN/strings.xml
+++ b/core/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~  This file is part of AndroidIDE.
+  ~
+  ~  AndroidIDE is free software: you can redistribute it and/or modify
+  ~  it under the terms of the GNU General Public License as published by
+  ~  the Free Software Foundation, either version 3 of the License, or
+  ~  (at your option) any later version.
+  ~
+  ~  AndroidIDE is distributed in the hope that it will be useful,
+  ~  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~  GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License
+  ~   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+
+<resources>
+  <!-- Asset Studio -->
+  <string name="asset_studio_title">资源工坊</string>
+  <string name="asset_studio_subtitle">可绘制资源与图标制作器</string>
+  <string name="asset_studio_launch">启动工坊</string>
+  <string name="asset_studio_create_drawable">创建可绘制资源</string>
+  <string name="asset_studio_create_icon">创建图标</string>
+  <string name="asset_studio_import_image">导入图片</string>
+  <string name="asset_studio_recent_assets">最近资源</string>
+  <string name="asset_studio_quick_actions">快捷操作</string>
+  <string name="asset_studio_default_path">res/drawable</string>
+  <string name="asset_studio_launch_description">打开完整的资源工坊界面</string>
+
+  <!-- Sub-Module Maker -->
+  <string name="sub_module_maker_title">子模块创建器</string>
+  <string name="sub_module_maker_subtitle">为您的项目创建新的子模块</string>
+  <string name="sub_module_configuration">模块配置</string>
+  <string name="sub_module_language">编程语言</string>
+  <string name="sub_module_kotlin">Kotlin</string>
+  <string name="sub_module_java">Java</string>
+  <string name="sub_module_name_hint">输入模块名称（例如：feature、utils）</string>
+  <string name="sub_module_name_valid">有效的模块名称</string>
+  <string name="sub_module_name_invalid">无效的模块名称</string>
+  <string name="sub_module_create">创建模块</string>
+  <string name="sub_module_created_success">模块「%1$s」创建成功！</string>
+  <string name="sub_module_created_error">创建模块失败：%1$s</string>
+  <string name="sub_module_info_title">关于子模块</string>
+  <string name="sub_module_info_description">子模块可将您的项目组织为更小、更易于管理的组件。每个模块都可以拥有自己的依赖项和构建配置。</string>
+
+  <!-- Terminal -->
+  <string name="title_terminal">终端</string>
+  <string name="terminal_bstab">终端</string>
+  <string name="terminal_new_session">新建终端</string>
+  <string name="terminal_close_session">关闭终端</string>
+  <string name="terminal_empty_state">无终端会话</string>
+  <string name="terminal_empty_message">当前没有打开的终端会话。创建一个新会话来开始使用。</string>
+  <string name="terminal_create_first">创建终端</string>
+
+  <string name="edit">编辑</string>
+</resources>


### PR DESCRIPTION
## 变更内容

### 🌐 中文支持优化
**问题：** 简体中文支持不完整，`core/app` 模块完全缺失中文翻译

**修复：** 新增 `core/app/src/main/res/values-zh-rCN/strings.xml`，翻译了所有用户可见字符串：
- 🎨 **资源工坊**（Asset Studio）—— 完整翻译
- 📦 **子模块创建器**（Sub-Module Maker）—— 完整翻译
- 💻 **终端**（Terminal）—— 完整翻译
- ✏️ 编辑按钮等通用字串

### 🤖 自动构建
构建流程已存在于 `.github/workflows/asm_build.yml`，在 `dev` 分支 push/PR 时会自动触发构建 Debug APK。

> 注：`core/resources` 模块的中文翻译已存在且较完整（`values-zh-rCN/strings.xml` 62KB），仅 `core/app` 模块缺少翻译，本次已补全。